### PR TITLE
#8 - 회원 정보에 접근할 repository 인터페이스, jpa 설정 및 jp 테스트 작성

### DIFF
--- a/src/main/java/com/web/board/admin/config/JpaConfig.java
+++ b/src/main/java/com/web/board/admin/config/JpaConfig.java
@@ -1,0 +1,28 @@
+package com.web.board.admin.config;
+
+import com.web.board.admin.dto.security.BoardAdminPrincipal;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+
+    @Bean
+    public AuditorAware<String> auditorAware() {
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .filter(Authentication::isAuthenticated)
+                .map(Authentication::getPrincipal)
+                .map(BoardAdminPrincipal.class::cast)
+                .map(BoardAdminPrincipal::getUsername);
+    }
+
+}

--- a/src/main/java/com/web/board/admin/repository/UserAccountRepository.java
+++ b/src/main/java/com/web/board/admin/repository/UserAccountRepository.java
@@ -1,0 +1,7 @@
+package com.web.board.admin.repository;
+
+import com.web.board.admin.domain.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,8 @@
+-- 테스트 계정
+-- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
+insert into user_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
+('uno', '{noop}asdf1234', 'ADMIN', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno'),
+('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'uno', now(), 'uno'),
+('susan', '{noop}asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'uno', now(), 'uno'),
+('jim', '{noop}asdf1234', 'USER', 'Jim', 'jim@mail.com', 'I am Jim.', now(), 'uno', now(), 'uno')
+;

--- a/src/test/java/com/web/board/admin/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/web/board/admin/repository/JpaRepositoryTest.java
@@ -1,0 +1,102 @@
+package com.web.board.admin.repository;
+
+import com.web.board.admin.domain.UserAccount;
+import com.web.board.admin.domain.constant.RoleType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("JPA 연결 테스트")
+@Import(JpaRepositoryTest.TestJpaConfig.class)
+@DataJpaTest
+class JpaRepositoryTest {
+
+    private final UserAccountRepository userAccountRepository;
+
+    public JpaRepositoryTest(@Autowired UserAccountRepository userAccountRepository) {
+        this.userAccountRepository = userAccountRepository;
+    }
+
+    @DisplayName("회원 정보 select 테스트")
+    @Test
+    void givenUserAccounts_whenSelecting_thenWorksFine() {
+        // Given
+
+        // When
+        List<UserAccount> userAccounts = userAccountRepository.findAll();
+
+        // Then
+        assertThat(userAccounts)
+                .isNotNull()
+                .hasSize(4);
+    }
+
+    @DisplayName("회원 정보 insert 테스트")
+    @Test
+    void givenUserAccount_whenInserting_thenWorksFine() {
+        // Given
+        long previousCount = userAccountRepository.count();
+        UserAccount userAccount = UserAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null);
+
+        // When
+        userAccountRepository.save(userAccount);
+
+        // Then
+        assertThat(userAccountRepository.count()).isEqualTo(previousCount + 1);
+    }
+
+    @DisplayName("회원 정보 update 테스트")
+    @Test
+    void givenUserAccountAndRoleType_whenUpdating_thenWorksFine() {
+        // Given
+        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
+        userAccount.addRoleType(RoleType.DEVELOPER);
+        userAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
+        userAccount.removeRoleType(RoleType.ADMIN);
+
+        // When
+        UserAccount updatedAccount = userAccountRepository.saveAndFlush(userAccount);
+
+        // Then
+        assertThat(updatedAccount)
+                .hasFieldOrPropertyWithValue("userId", "uno")
+                .hasFieldOrPropertyWithValue("roleTypes", Set.of(RoleType.DEVELOPER, RoleType.USER));
+    }
+
+    @DisplayName("회원 정보 delete 테스트")
+    @Test
+    void givenUserAccount_whenDeleting_thenWorksFine() {
+        // Given
+        long previousCount = userAccountRepository.count();
+        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
+
+        // When
+        userAccountRepository.delete(userAccount);
+
+        // Then
+        assertThat(userAccountRepository.count()).isEqualTo(previousCount - 1);
+    }
+
+
+    @EnableJpaAuditing
+    @TestConfiguration
+    static class TestJpaConfig {
+        @Bean
+        AuditorAware<String> auditorAware() {
+            return () -> Optional.of("uno");
+        }
+    }
+
+}


### PR DESCRIPTION
회원 데이터에 접근할 리포지토리 인터페이스와
jpa auditing 기능을 활성화시킬 `JpaConfig`,
각자 다른 권한을 가진 테스트용 회원 데이터,
crud 쿼리 생성을 확인할 jpa 테스트 작성

This closes #8 